### PR TITLE
Replace all occurrences when replacing, not just the first

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -55,7 +55,7 @@ exports.hashAndSub = function(grunt, options) {
         var destContents = fs.readFileSync(f, encoding);
         for (var name in nameToHashedName) {
           grunt.log.debug('Substituting ' + name + ' by ' + nameToHashedName[name]);
-          destContents = destContents.replace(name, nameToHashedName[name]);
+          destContents = destContents.replace(new RegExp(name, "g"), nameToHashedName[name]);
         }
         grunt.log.debug('Saving the updated contents of the outination file');
         fs.writeFileSync(f, destContents, encoding);


### PR DESCRIPTION
We're using grunt-hashres to hash our image resources, in addition to JS and CSS. Since the same image can be used multiple times in a CSS file, we uncovered a bug where hashres only replaces the first occurrence. This pull request fixes it to replace all.
