### PR TITLE
Match hashed filename on subsequent builds

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -55,7 +55,9 @@ exports.hashAndSub = function(grunt, options) {
         var destContents = fs.readFileSync(f, encoding);
         for (var name in nameToHashedName) {
           grunt.log.debug('Substituting ' + name + ' by ' + nameToHashedName[name]);
-          destContents = destContents.replace(new RegExp(name, "g"), nameToHashedName[name]);
+          var hashMatch = new RegExp('[a-z0-9]{8}.' + name, "g");
+          var rx = ( hashMatch.test(destContents) ) ? hashMatch : new RegExp(name, "g");
+          destContents = destContents.replace(rx, nameToHashedName[name]);
         }
         grunt.log.debug('Saving the updated contents of the outination file');
         fs.writeFileSync(f, destContents, encoding);


### PR DESCRIPTION
This is my first pull request, so bear with me :-)
# The issue

Replacing the orignal filenames with the hashed name worked fine the first time the task was run. On subsequent runs however, the regex would match the original filename as a substring of the hashed name, and replace that substring with the hashed name again. The result looked like this after 3 runs:

4a2e4963.4a2e4963.4a2e4963.script.min.js

... which broke the reference to the hashed file.
# The fix

I fixed the issue by first checking the contents of the destination file for a match against the hashed filename using:

 <pre>RegExp('[a-z0-9]{8}.' + name, "g");</pre>

If that match is found, it is used during the replace. Otherwise, the replace uses the original match on <pre>name</pre>
