### PR TITLE
Escape filename

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -12,6 +12,22 @@ var fs    = require('fs'),
     path  = require('path'),
     utils = require('./hashresUtils');
 
+function preg_quote (str, delimiter) {
+  // http://kevin.vanzonneveld.net
+  // +   original by: booeyOH
+  // +   improved by: Ates Goral (http://magnetiq.com)
+  // +   improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+  // +   bugfixed by: Onno Marsman
+  // +   improved by: Brett Zamir (http://brett-zamir.me)
+  // *     example 1: preg_quote("$40");
+  // *     returns 1: '\$40'
+  // *     example 2: preg_quote("*RRRING* Hello?");
+  // *     returns 2: '\*RRRING\* Hello\?'
+  // *     example 3: preg_quote("\\.+*?[^]$(){}=!<>|:");
+  // *     returns 3: '\\\.\+\*\?\[\^\]\$\(\)\{\}\=\!\<\>\|\:'
+  return (str + '').replace(new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\' + (delimiter || '') + '-]', 'g'), '\\$&');
+}
+
 exports.hashAndSub = function(grunt, options) {
 
   var src              = options.src,
@@ -55,7 +71,7 @@ exports.hashAndSub = function(grunt, options) {
         var destContents = fs.readFileSync(f, encoding);
         for (var name in nameToHashedName) {
           grunt.log.debug('Substituting ' + name + ' by ' + nameToHashedName[name]);
-          destContents = destContents.replace(new RegExp(name, "g"), nameToHashedName[name]);
+          destContents = destContents.replace(new RegExp(preg_quote(name), "g"), nameToHashedName[name]);
         }
         grunt.log.debug('Saving the updated contents of the outination file');
         fs.writeFileSync(f, destContents, encoding);


### PR DESCRIPTION
If the filename have special characters it may end up throwing an exception (for instance +1.png). Added preg_quote (borrowed from phpjs.org) to fix this issue
