### PR TITLE
Updated the regex to make it work when putting the hash after '?'

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -71,7 +71,7 @@ exports.hashAndSub = function(grunt, options) {
         var destContents = fs.readFileSync(f, encoding);
         for (var name in nameToHashedName) {
           grunt.log.debug('Substituting ' + name + ' by ' + nameToHashedName[name]);
-          destContents = destContents.replace(new RegExp(preg_quote(name), "g"), nameToHashedName[name]);
+          destContents = destContents.replace(new RegExp(preg_quote(name)+"(\\?[0-9a-z]+)?", "g"), nameToHashedName[name]);
         }
         grunt.log.debug('Saving the updated contents of the outination file');
         fs.writeFileSync(f, destContents, encoding);


### PR DESCRIPTION
I am using `${name}.${ext}?${hash}` as `fileNameFormat` and I noticed the task appended the hash each time, without clearing the last one.

This commit is my attempt to fix it. It works for me, but it is not as universal as it should be, I suppose.
