### PR TITLE
A fix for issue #40

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -77,10 +77,10 @@ exports.hashAndSub = function(grunt, options) {
       grunt.file.expand(f.dest).forEach(function(f) {
         var destContents = fs.readFileSync(f, encoding);
         files.forEach(function(value) {
-          grunt.log.debug('Substituting ' + value[0] + ' by ' + value[1])
-          destContents = destContents.replace(new RegExp(utils.preg_quote(value[0])+"(\\?[0-9a-z]+)?", "g"), value[1]);
+          grunt.log.debug('Substituting ' + value[0] + ' by ' + value[1]);
+          destContents = destContents.replace(new RegExp("([\'\"\/])"+utils.preg_quote(value[0])+"(\\?[0-9a-z]+)?", "g"), "$1"+value[1]);
 
-          grunt.log.debug('Substituting ' + nameToNameSearch[value[0]] + ' by ' + value[1])
+          grunt.log.debug('Substituting ' + nameToNameSearch[value[0]] + ' by ' + value[1]);
           destContents = destContents.replace(
                 new RegExp(nameToNameSearch[value[0]], "g"), 
                 value[1]

--- a/test/fixtures/partial/index.html
+++ b/test/fixtures/partial/index.html
@@ -1,0 +1,3 @@
+<html>
+  <head><script type="text/javascript" src="myscripts.js"></script><script type="text/javascript" src="mobile-myscripts.js"></script></head>
+</html>

--- a/test/fixtures/partial/mobile-myscripts.js
+++ b/test/fixtures/partial/mobile-myscripts.js
@@ -1,0 +1,3 @@
+(function() {
+  // Nothing to do
+})

--- a/test/fixtures/partial/myscripts.js
+++ b/test/fixtures/partial/myscripts.js
@@ -1,0 +1,3 @@
+(function() {
+  // Nothing to do
+})

--- a/test/hashresHelper.spec.js
+++ b/test/hashresHelper.spec.js
@@ -60,6 +60,23 @@ vows.describe('hashresHelper').addBatch({
       assert(html.indexOf('scripts/5a7a5b61-myscripts2.js') !== -1);
       assert(html.indexOf('styles/3b97b071-mystyles1.css') !== -1);
       assert(html.indexOf('styles/3b97b071-mystyles2.css') !== -1);
-    }
+    },
+    'for partial sample': function(grunt) {
+      helper.hashAndSub(
+        grunt, {
+          files: [{
+            src  : ['./temp/helper/partial/myscripts.js'],
+            dest : './temp/helper/partial/index.html',
+          }],
+          fileNameFormat: '${hash}.${name}.cache.${ext}',
+          encoding      : 'utf8',
+          renameFiles   : true
+        });
+      assert(fs.existsSync('./temp/helper/partial/5a7a5b61.myscripts.cache.js'));
+
+      var html = fs.readFileSync('./temp/helper/partial/index.html', 'utf8');
+      assert(html.indexOf('5a7a5b61.myscripts.cache.js') !== -1);
+      assert(html.indexOf('mobile-5a7a5b61.myscripts.cache.js') === -1);
+    },
   }
 }).export(module);


### PR DESCRIPTION
Partial file names. Files names with same prefix where mistakenly matched. For example: Both "scripts/main.js" and "scripts/mobile-main.js" where a match to "main.js" file. I added regex fix in order to  match only exact file
names (regex added is "([\'\"\/])" for matching names staring with ', " or /. This fixed the issue.
I added unitests (which fails without this fix).