### PR TITLE
Fixed handling of resources with query string.

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -60,8 +60,8 @@ exports.hashAndSub = function(grunt, options) {
         grunt.log.write(src + ' ').ok(renamed);
       });
 
-      // sort by length 
-      // It is very useful when we have bar.js and foo-bar.js 
+      // sort by length
+      // It is very useful when we have bar.js and foo-bar.js
       // @crodas
       var files = [];
       for (var name in nameToHashedName) {
@@ -78,11 +78,11 @@ exports.hashAndSub = function(grunt, options) {
         var destContents = fs.readFileSync(f, encoding);
         files.forEach(function(value) {
           grunt.log.debug('Substituting ' + value[0] + ' by ' + value[1])
-          destContents = destContents.replace(new RegExp(utils.preg_quote(value[0])+"(\\?[0-9a-z]+)?", "g"), value[1]);
+          destContents = destContents.replace(new RegExp(utils.preg_quote(value[0])+"(\\?[0-9a-f]{8}$)?", "g"), value[1]);
 
           grunt.log.debug('Substituting ' + nameToNameSearch[value[0]] + ' by ' + value[1])
           destContents = destContents.replace(
-                new RegExp(nameToNameSearch[value[0]], "g"), 
+                new RegExp(nameToNameSearch[value[0]], "g"),
                 value[1]
             );
         });

--- a/test/fixtures/resource-with-qs/index.html
+++ b/test/fixtures/resource-with-qs/index.html
@@ -1,0 +1,3 @@
+<html>
+  <head><script type="text/javascript" src="myscripts.js?v=0.1"></script></head>
+</html>

--- a/test/fixtures/resource-with-qs/myscripts.js
+++ b/test/fixtures/resource-with-qs/myscripts.js
@@ -1,0 +1,3 @@
+(function() {
+  // Nothing to do
+})

--- a/test/hashresHelper.spec.js
+++ b/test/hashresHelper.spec.js
@@ -60,6 +60,21 @@ vows.describe('hashresHelper').addBatch({
       assert(html.indexOf('scripts/5a7a5b61-myscripts2.js') !== -1);
       assert(html.indexOf('styles/3b97b071-mystyles1.css') !== -1);
       assert(html.indexOf('styles/3b97b071-mystyles2.css') !== -1);
-    }
+    },
+    'for sample with query string': function(grunt) {
+      helper.hashAndSub(
+        grunt, {
+          files: [{
+            src  : ['./temp/helper/resource-with-qs/myscripts.js'],
+            dest : './temp/helper/resource-with-qs/index.html',
+          }],
+          fileNameFormat: '${hash}.${name}.cache.${ext}',
+          encoding      : 'utf8',
+          renameFiles   : true
+        });
+      assert(fs.existsSync('./temp/helper/resource-with-qs/5a7a5b61.myscripts.cache.js'));
+      var html = fs.readFileSync('./temp/helper/resource-with-qs/index.html', 'utf8');
+      assert(html.indexOf('?v=0.1') !== -1, 'Query string ?v=0.1 missing or broken.');
+    },
   }
 }).export(module);


### PR DESCRIPTION
This is also a solution for #52 (haven't seen that there was one already). 

Anyway, this pull request also contains a test, but the implementation keeps hashres' intention to drop the *query string hash* generated by hashres itself (this is the case when format is `${name}.${ext}?${hash}` as listed in Readme).